### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ And the step filename will be added to your `steps/list.json` file with position
 ]
 ```
 
-You can add your own `data-` attributes but be carefull, as the file has to be valid `json`. 
+You can add your own `data-` attributes but be careful, as the file has to be valid `json`. 
 
 
 ## License


### PR DESCRIPTION
@slara, I've corrected a typographical error in the documentation of the [generator-impress](https://github.com/slara/generator-impress) project. Specifically, I've changed carefull to careful. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.